### PR TITLE
fix: use colors-dark in foot.ini

### DIFF
--- a/foot.ini
+++ b/foot.ini
@@ -69,7 +69,7 @@
 # hide-when-typing=no
 # alternate-scroll-mode=yes
 
-[colors]
+[colors-dark]
 # alpha=1.0
 background=282a36
 foreground=f8f8f2


### PR DESCRIPTION
As of [foot release 1.26.0](https://codeberg.org/dnkl/foot/releases/tag/1.26.0) the `[colors]` section is deprecated, and should be replaced by `[colors-dark]` or `[colors-light]`.

This PR updates `colors` to `colors-dark`. 🧛